### PR TITLE
Issue-3: Add initial aaeon images

### DIFF
--- a/meta-aaeon-bsp/conf/layer.conf
+++ b/meta-aaeon-bsp/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-aaeon-bsp"
+BBFILE_PATTERN_meta-aaeon-bsp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-aaeon-bsp = "7"
+
+LAYERDEPENDS_meta-aaeon-bsp = "core meta-aaeon jetson-agx-xavier-devkit"
+LAYERSERIES_COMPAT_meta-aaeon-bsp = "mickledore"

--- a/meta-aaeon/conf/layer.conf
+++ b/meta-aaeon/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-aaeon"
+BBFILE_PATTERN_meta-aaeon = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-aaeon = "6"
+
+LAYERDEPENDS_meta-aaeon = "core openembedded-layer networking-layer"
+LAYERSERIES_COMPAT_meta-aaeon = "mickledore"

--- a/meta-aaeon/recipes-core/images/aaeon-image-base.bb
+++ b/meta-aaeon/recipes-core/images/aaeon-image-base.bb
@@ -1,0 +1,6 @@
+SUMMARY = "AAEON Base OS Image"
+LICENSE = "MIT"
+
+require recipes-core/images/aaeon-image-common.inc
+
+IMAGE_FEATURES += "read-only-rootfs"

--- a/meta-aaeon/recipes-core/images/aaeon-image-common.inc
+++ b/meta-aaeon/recipes-core/images/aaeon-image-common.inc
@@ -1,0 +1,14 @@
+inherit core-image
+
+IMAGE_ROOTFS_SIZE ?= "8192"
+IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"
+
+IMAGE_FEATURES += "ssh-server-openssh"
+IMAGE_FEATURES += "package-management"
+
+IMAGE_INSTALL = " \
+    ${CORE_IMAGE_BASE_INSTALL} \
+    packagegroup-core-full-cmdline \
+    packagegroup-aaeon-core \
+    packagegroup-aaeon-image \
+"

--- a/meta-aaeon/recipes-core/images/aaeon-image-devel.bb
+++ b/meta-aaeon/recipes-core/images/aaeon-image-devel.bb
@@ -1,0 +1,8 @@
+SUMMARY = "AAEON Development OS Image"
+LICENSE = "MIT"
+
+require recipes-core/images/aaeon-image-common.inc
+
+IMAGE_INSTALL += " \
+    packagegroup-aaeon-image-development \
+"

--- a/meta-aaeon/recipes-core/packagegroups/packagegroup-aaeon-core.bb
+++ b/meta-aaeon/recipes-core/packagegroups/packagegroup-aaeon-core.bb
@@ -1,0 +1,67 @@
+SUMMARY = "AAEON Core packagegroups"
+
+inherit packagegroup
+
+PROVIDES = "${PACKAGES}"
+PACKAGES = " \
+    ${PN} \
+    ${PN}-development \
+    ${PN}-kernel-tools \
+    ${PN}-kernel-development \
+    ${PN}-development-tools \
+    ${PN}-sys-debug \
+    ${PN}-editors \
+    ${PN}-time-sync \
+"
+
+RDEPENDS:${PN} = " \
+    ${PN}-time-sync \
+"
+
+RDEPENDS:${PN}-development = " \
+    ${PN}-kernel-tools \
+    ${PN}-kernel-development \
+    ${PN}-sys-debug \
+    ${PN}-development-tools \
+    ${PN}-editors \
+    \
+    packagegroup-sdk-target \
+"
+
+RDEPENDS:${PN}-kernel-tools = " \
+    kexec-tools \
+    kdump \
+    crash \
+    makedumpfile \
+    dtc \
+"
+
+RDEPENDS:${PN}-kernel-development = " \
+    ${PN}-kernel-tools \
+    \
+    kernel-dev \
+    kernel-devsrc \
+    kernel-devsrc-dbg \
+"
+
+RDEPENDS:${PN}-development-tools = " \
+    git \
+    xz \
+"
+
+RDEPENDS:${PN}-sys-debug = " \
+    gdb \
+    stress-ng \
+    ldd \
+"
+
+RDEPENDS:${PN}-editors = " \
+    nano \
+    vim \
+"
+
+# NTP support via the chrony daemon
+RDEPENDS:${PN}-time-sync = " \
+    chrony \
+    chronyc \
+"

--- a/meta-aaeon/recipes-core/packagegroups/packagegroup-aaeon-image.bb
+++ b/meta-aaeon/recipes-core/packagegroups/packagegroup-aaeon-image.bb
@@ -1,0 +1,19 @@
+SUMMARY = "AAEON Core image packagegroups"
+
+inherit packagegroup
+
+PROVIDES = "${PACKAGES}"
+PACKAGES = " \
+    ${PN} \
+    ${PN}-development \
+"
+
+RDEPENDS:${PN} = " \
+    networkd-config \
+"
+
+RDEPENDS:${PN}-development = " \
+    ${PN} \
+    \
+    packagegroup-aaeon-core-development \
+"

--- a/meta-aaeon/recipes-network/networkd-config/networkd-config/75-eth0.network
+++ b/meta-aaeon/recipes-network/networkd-config/networkd-config/75-eth0.network
@@ -1,0 +1,13 @@
+[Match]
+Name=eth0
+
+[Address]
+Address=192.168.88.5/24
+
+[Network]
+DHCP=yes
+IPv4LL=yes
+MulticastDNS=yes
+
+[DHCP]
+ClientIdentifier=mac

--- a/meta-aaeon/recipes-network/networkd-config/networkd-config_1.0.bb
+++ b/meta-aaeon/recipes-network/networkd-config/networkd-config_1.0.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Networkd Configuration Files"
+SECTION = "net/config"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = ""
+
+SRC_URI:append = " \
+    file://75-eth0.network \
+"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -m 0755 -d ${D}${systemd_unitdir}/network
+}
+
+do_install:append() {
+    install -m 0644 ${S}/75-eth0.network ${D}${systemd_unitdir}/network
+}
+
+FILES:${PN} += "${systemd_unitdir}/network"


### PR DESCRIPTION
Added AAEON base OS images. This allows building basic AAEON images with `bitbake aaeon-image-base` and `bitbake aaeon-image-devel`. These images have full command line intefaces and run openssh.